### PR TITLE
Spinner is not visible while application list is being fetched #106

### DIFF
--- a/src/main/resources/assets/js/app/installation/InstallAppDialog.ts
+++ b/src/main/resources/assets/js/app/installation/InstallAppDialog.ts
@@ -1,17 +1,16 @@
-import '../../api.ts';
 import {ApplicationInput} from './view/ApplicationInput';
 import {MarketAppsTreeGrid} from './view/MarketAppsTreeGrid';
 import {ApplicationUploaderEl} from './ApplicationUploaderEl';
 import {ApplicationUploadStartedEvent} from '../browse/ApplicationUploadStartedEvent';
 import TreeNode = api.ui.treegrid.TreeNode;
 import Application = api.application.Application;
-import i18n = api.util.i18n;
 import DivEl = api.dom.DivEl;
 import MarketApplication = api.application.MarketApplication;
 import UploadFailedEvent = api.ui.uploader.UploadFailedEvent;
 import UploadStartedEvent = api.ui.uploader.UploadStartedEvent;
 import ButtonEl = api.dom.ButtonEl;
 import StringHelper = api.util.StringHelper;
+import i18n = api.util.i18n;
 
 export class InstallAppDialog
     extends api.ui.dialog.ModalDialog {
@@ -59,15 +58,10 @@ export class InstallAppDialog
 
         this.applicationInput.onTextValueChanged(() => {
             this.clearButton.setVisible(!StringHelper.isEmpty(this.applicationInput.getValue()));
+            this.marketAppsTreeGrid.mask();
             this.marketAppsTreeGrid.refresh();
         });
 
-        const showMask = api.util.AppHelper.debounce(this.marketAppsTreeGrid.mask.bind(this.marketAppsTreeGrid), 300, false);
-        this.applicationInput.getTextInput().onValueChanged(() => {
-            if (!this.applicationInput.isUrlTyped()) {
-                showMask();
-            }
-        });
         this.applicationInput.onAppInstallStarted(() => {
             this.marketAppsTreeGrid.mask();
             this.statusMessage.showInstalling();

--- a/src/main/resources/assets/js/app/installation/view/ApplicationInput.ts
+++ b/src/main/resources/assets/js/app/installation/view/ApplicationInput.ts
@@ -10,9 +10,12 @@ import UploadFailedEvent = api.ui.uploader.UploadFailedEvent;
 
 export class ApplicationInput extends api.dom.CompositeFormInputEl {
 
+    private static LAST_KEY_PRESS_TIMEOUT: number = 300;
+
     private textInput: InputEl;
+
     private applicationUploaderEl: ApplicationUploaderEl;
-    private LAST_KEY_PRESS_TIMEOUT: number;
+
     private cancelAction: Action;
 
     private textValueChangedListeners: {(): void}[] = [];
@@ -40,7 +43,6 @@ export class ApplicationInput extends api.dom.CompositeFormInputEl {
             showCancel: false
         }));
 
-        this.LAST_KEY_PRESS_TIMEOUT = 750;
         this.cancelAction = cancelAction;
 
         this.applicationUploaderEl.onUploadStarted((event: UploadStartedEvent<Application>) => {
@@ -67,7 +69,7 @@ export class ApplicationInput extends api.dom.CompositeFormInputEl {
     }
 
     private initUrlEnteredHandler() {
-        const keyDownHandler: () => void = api.util.AppHelper.debounce(this.startInstall.bind(this), this.LAST_KEY_PRESS_TIMEOUT);
+        const keyDownHandler: () => void = api.util.AppHelper.debounce(() => this.startInstall(), ApplicationInput.LAST_KEY_PRESS_TIMEOUT);
 
         this.onKeyDown((event) => {
             switch (event.keyCode) {


### PR DESCRIPTION
* Removed debounced grid mask, after user types something, since we load all the application when the dialog opens.
* Decreased the delay for the reaction on user input in the dialog.

When the user opens the dialog for the first time, the spinner in the dialog will be shown (fixed in the previous PR) and __*all*__ the applications will be loaded.
After the grid is filtered, the mask in the __*grid*__ will be shown, but the user won't notice it since the grid will be filtered almost instantly.
Previously, when the user has been clearing the input, while the grid was empty ("No applications found" is displayed), the mask with a spinner was displayed afterward with a delay of 300ms, and the actual filter was executed after 750ms. 
Since there are no requests sent on the filter, and the grid filters instantly, we don't need such a long delay. I've decreased the reaction on the user filter to the 300ms and removed the delayed mask show. The mask will be shown only on the grid refresh.