### PR TITLE
Searching for applications briefly shows wrong UI #449

### DIFF
--- a/src/main/resources/assets/js/app/installation/InstallAppDialog.ts
+++ b/src/main/resources/assets/js/app/installation/InstallAppDialog.ts
@@ -104,12 +104,7 @@ export class InstallAppDialog
 
         this.marketAppsTreeGrid.onLoaded(() => {
             this.statusMessage.reset();
-
-            if (this.marketAppsTreeGrid.isDataViewEmpty()) {
-                this.statusMessage.showNoResult();
-            } else {
-                this.statusMessage.hide();
-            }
+            this.toggleStatusMessage(this.marketAppsTreeGrid.isDataViewEmpty());
             this.removeClass('loading');
             this.notifyResize();
         });
@@ -143,13 +138,24 @@ export class InstallAppDialog
         this.marketAppsTreeGrid.onRowCountChanged((event, data) => {
             const isLoading = this.hasClass('loading');
             if (!isLoading) {
-                if (data.current < 1) {
-                    this.statusMessage.showNoResult();
-                } else {
-                    this.statusMessage.hide();
-                }
+                this.toggleStatusMessage(data.current < 1);
             }
         });
+    }
+
+    private toggleStatusMessage(showStatus: boolean) {
+        if (showStatus) {
+            this.statusMessage.showNoResult();
+            if (this.getBody().isVisible()) {
+                this.getBody().hide();
+            }
+        } else {
+            this.statusMessage.hide();
+            if (!this.getBody().isVisible()) {
+                this.getBody().show();
+                this.marketAppsTreeGrid.getGrid().resizeCanvas();
+            }
+        }
     }
 
     updateInstallApplications(installApplications: Application[]) {

--- a/src/main/resources/assets/js/app/installation/view/ApplicationInput.ts
+++ b/src/main/resources/assets/js/app/installation/view/ApplicationInput.ts
@@ -16,7 +16,7 @@ import {ApplicationInstallResult} from '../../resource/ApplicationInstallResult'
 export class ApplicationInput
     extends CompositeFormInputEl {
 
-    private static LAST_KEY_PRESS_TIMEOUT: number = 300;
+    private static LAST_KEY_PRESS_TIMEOUT: number = 100;
 
     private textInput: InputEl;
 
@@ -117,10 +117,6 @@ export class ApplicationInput
         return this;
     }
 
-    public hasMatchInEntry(entry: string): boolean {
-        return entry.toLowerCase().indexOf(this.getValue().toLowerCase()) > -1;
-    }
-
     getTextInput(): InputEl {
         return this.textInput;
     }
@@ -128,6 +124,7 @@ export class ApplicationInput
     reset(): ApplicationInput {
         this.textInput.reset();
         this.applicationUploaderEl.reset();
+        this.notifyTextValueChanged();
         return this;
     }
 

--- a/src/main/resources/assets/js/app/installation/view/MarketAppsTreeGrid.ts
+++ b/src/main/resources/assets/js/app/installation/view/MarketAppsTreeGrid.ts
@@ -77,7 +77,6 @@ export class MarketAppsTreeGrid
                 this.getCurrentData();
                 const marketApps = this.getRoot().getAllNodes().map(node => node.getData());
                 this.updateAppsStatuses(marketApps);
-                this.invalidate();
             }
         });
     }

--- a/src/main/resources/assets/js/app/installation/view/MarketAppsTreeGridHelper.ts
+++ b/src/main/resources/assets/js/app/installation/view/MarketAppsTreeGridHelper.ts
@@ -109,4 +109,17 @@ export class MarketAppsTreeGridHelper {
 
         return 0;
     }
+
+    public static compareAppsByStatus(app1: MarketApplication, app2: MarketApplication): number {
+        if ((app1.getStatus() === MarketAppStatus.OLDER_VERSION_INSTALLED) &&
+            (app2.getStatus() === MarketAppStatus.OLDER_VERSION_INSTALLED)) {
+            return app1.getDisplayName().localeCompare(app2.getDisplayName());
+        }
+
+        if (app1.getStatus() === MarketAppStatus.OLDER_VERSION_INSTALLED) {
+            return -1;
+        }
+
+        return 1;
+    }
 }

--- a/src/main/resources/assets/js/app/resource/ApplicationInstallResult.ts
+++ b/src/main/resources/assets/js/app/resource/ApplicationInstallResult.ts
@@ -12,7 +12,8 @@ export class ApplicationInstallResult
 
     static fromJson(json: ApplicationInstallResultJson): ApplicationInstallResult {
         let result = new ApplicationInstallResult();
-        result.application = json.applicationInstalledJson ? Application.fromJson(json.applicationInstalledJson) : null;
+        const applicationJson = json.applicationInstalledJson?.application;
+        result.application = applicationJson ? Application.fromJson(applicationJson) : null;
         result.failure = json.failure;
         return result;
     }

--- a/src/main/resources/assets/js/app/resource/json/ApplicationInstallResultJson.ts
+++ b/src/main/resources/assets/js/app/resource/json/ApplicationInstallResultJson.ts
@@ -1,8 +1,8 @@
-import {ApplicationJson} from 'lib-admin-ui/application/json/ApplicationJson';
+import {ApplicationInstalledJson} from './ApplicationInstalledJson';
 
 export interface ApplicationInstallResultJson {
 
-    applicationInstalledJson: ApplicationJson;
+    applicationInstalledJson: ApplicationInstalledJson;
 
     failure: string;
 }

--- a/src/main/resources/assets/js/app/resource/json/ApplicationInstalledJson.ts
+++ b/src/main/resources/assets/js/app/resource/json/ApplicationInstalledJson.ts
@@ -1,0 +1,5 @@
+import {ApplicationJson} from 'lib-admin-ui/application/json/ApplicationJson';
+
+export interface ApplicationInstalledJson {
+    application: ApplicationJson;
+}

--- a/src/main/resources/assets/styles/installation/market-app-tree-grid.less
+++ b/src/main/resources/assets/styles/installation/market-app-tree-grid.less
@@ -90,6 +90,7 @@
 
           .progress-bar {
             display: block;
+            background-color: @admin-bg-light-gray;
           }
         }
 


### PR DESCRIPTION
* Updated filter to use native functions of TreeGrid instead of reloading Grid on every new text input.
* Removed constant Grid reload and full apps list requests, replacing them by a single one, before the MarketList even shown for better UX.
* Decreased last key pressed timeout for ApplicationInput since we no longer load data from the server for every new input value.
* Optimized other requests with server event handling and further apps status updates.

_Depends on PR #560_