### PR TITLE
Prevent install app dialog scrolling when pressing upload button #1899

### DIFF
--- a/src/main/resources/assets/js/app/installation/InstallAppDialog.ts
+++ b/src/main/resources/assets/js/app/installation/InstallAppDialog.ts
@@ -28,6 +28,8 @@ export class InstallAppDialog
 
     private marketAppsTreeGrid: MarketAppsTreeGrid;
 
+    private uploadDialogActive: boolean = false;
+
     constructor() {
         super({
             title: i18n('dialog.install'),
@@ -112,6 +114,18 @@ export class InstallAppDialog
                 this.enableAndFocusInput();
             }
         });
+
+        this.applicationInput.getUploader().getUploadButton().onClicked(() => {
+            this.uploadDialogActive = true;
+
+            setTimeout(() => {
+               this.uploadDialogActive = false;
+            }, 500);
+        });
+    }
+
+    isMasked(): boolean {
+        return this.uploadDialogActive || super.isMasked();
     }
 
     private disableInput() {


### PR DESCRIPTION
- Issue is caused by the focus event that tries to bring focus back to the dialog after pressing upload button
- Using a workaround to avoid updating lib-admin and avoid focus manipulation after pressing upload