### PR TITLE
Show system apps in the list #141

### DIFF
--- a/src/main/java/com/enonic/xp/app/applications/rest/resource/application/AppsApplicationResource.java
+++ b/src/main/java/com/enonic/xp/app/applications/rest/resource/application/AppsApplicationResource.java
@@ -145,25 +145,22 @@ public final class AppsApplicationResource
         for ( final Application application : applications )
         {
             final ApplicationKey applicationKey = application.getKey();
-            if ( !application.isSystem() )
-            {
-                final CmsDescriptor cmsDescriptor = this.cmsService.getDescriptor( applicationKey );
-                final IdProviderDescriptor idProviderDescriptor = this.idProviderDescriptorService.getDescriptor( applicationKey );
-                final boolean localApplication = this.applicationService.isLocalApplication( applicationKey );
-                final ApplicationDescriptor appDescriptor = this.applicationDescriptorService.get( applicationKey );
+            final CmsDescriptor cmsDescriptor = this.cmsService.getDescriptor( applicationKey );
+            final IdProviderDescriptor idProviderDescriptor = this.idProviderDescriptorService.getDescriptor( applicationKey );
+            final boolean localApplication = this.applicationService.isLocalApplication( applicationKey );
+            final ApplicationDescriptor appDescriptor = this.applicationDescriptorService.get( applicationKey );
 
-                appJsonList.add( ApplicationJson.create()
-                                     .setApplication( application )
-                                     .setLocal( localApplication )
-                                     .setApplicationDescriptor( appDescriptor )
-                                     .setCmsDescriptor( cmsDescriptor )
-                                     .setIdProviderDescriptor( idProviderDescriptor )
-                                     .setIconUrlResolver( new ApplicationIconUrlResolver( request ) )
-                                     .setLocaleMessageResolver( new LocaleMessageResolver( this.localeService, applicationKey,
-                                                                                           Collections.list( request.getLocales() ) ) )
-                                     .setInlineMixinResolver( new CmsFormFragmentServiceResolver( this.cmsFormFragmentService ) )
-                                     .build() );
-            }
+            appJsonList.add( ApplicationJson.create()
+                                 .setApplication( application )
+                                 .setLocal( localApplication )
+                                 .setApplicationDescriptor( appDescriptor )
+                                 .setCmsDescriptor( cmsDescriptor )
+                                 .setIdProviderDescriptor( idProviderDescriptor )
+                                 .setIconUrlResolver( new ApplicationIconUrlResolver( request ) )
+                                 .setLocaleMessageResolver( new LocaleMessageResolver( this.localeService, applicationKey,
+                                                                                       Collections.list( request.getLocales() ) ) )
+                                 .setInlineMixinResolver( new CmsFormFragmentServiceResolver( this.cmsFormFragmentService ) )
+                                 .build() );
         }
 
         appJsonList.sort( Comparator.comparing(

--- a/src/main/java/com/enonic/xp/app/applications/rest/resource/application/json/ApplicationJson.java
+++ b/src/main/java/com/enonic/xp/app/applications/rest/resource/application/json/ApplicationJson.java
@@ -117,6 +117,11 @@ public class ApplicationJson
         return local;
     }
 
+    public boolean getSystem()
+    {
+        return application.isSystem();
+    }
+
     public FormJson getConfig()
     {
         return config;

--- a/src/main/resources/assets/js/app/SystemAppsHelper.ts
+++ b/src/main/resources/assets/js/app/SystemAppsHelper.ts
@@ -1,0 +1,35 @@
+import {Application} from '@enonic/lib-admin-ui/application/Application';
+
+export class SystemAppsHelper {
+
+    private static instance: SystemAppsHelper | null = null;
+
+    private readonly systemKeys: Set<string> = new Set<string>();
+
+    static get(): SystemAppsHelper {
+        if (!SystemAppsHelper.instance) {
+            SystemAppsHelper.instance = new SystemAppsHelper();
+        }
+        return SystemAppsHelper.instance;
+    }
+
+    setSystemFlag(key: string, isSystem: boolean): void {
+        if (isSystem) {
+            this.systemKeys.add(key);
+        } else {
+            this.systemKeys.delete(key);
+        }
+    }
+
+    isSystemApp(application: Application | null | undefined): boolean {
+        if (!application) {
+            return false;
+        }
+        const key = application.getApplicationKey().toString();
+        return this.systemKeys.has(key);
+    }
+
+    isSystemKey(key: string): boolean {
+        return this.systemKeys.has(key);
+    }
+}

--- a/src/main/resources/assets/js/app/browse/ApplicationBrowseActions.ts
+++ b/src/main/resources/assets/js/app/browse/ApplicationBrowseActions.ts
@@ -7,6 +7,7 @@ import {TreeGridActions} from '@enonic/lib-admin-ui/ui/treegrid/actions/TreeGrid
 import {Application} from '@enonic/lib-admin-ui/application/Application';
 import {Action} from '@enonic/lib-admin-ui/ui/Action';
 import {SelectableListBoxWrapper} from '@enonic/lib-admin-ui/ui/selector/list/SelectableListBoxWrapper';
+import {SystemAppsHelper} from '../SystemAppsHelper';
 
 export class ApplicationBrowseActions implements TreeGridActions<Application> {
 
@@ -39,6 +40,8 @@ export class ApplicationBrowseActions implements TreeGridActions<Application> {
             let anyStarted = false;
             let anyStopped = false;
             let localAppSelected = false;
+            let systemAppSelected = false;
+            const helper = SystemAppsHelper.get();
 
             browseItems.forEach((browseItem: Application) => {
                 let state = browseItem.getState();
@@ -50,11 +53,14 @@ export class ApplicationBrowseActions implements TreeGridActions<Application> {
                 if (browseItem.isLocal()) {
                     localAppSelected = true;
                 }
+                if (helper.isSystemApp(browseItem)) {
+                    systemAppSelected = true;
+                }
             });
 
             this.START_APPLICATION.setEnabled(anyStopped);
-            this.STOP_APPLICATION.setEnabled(anyStarted);
-            this.UNINSTALL_APPLICATION.setEnabled(anySelected && !localAppSelected);
+            this.STOP_APPLICATION.setEnabled(anyStarted && !systemAppSelected);
+            this.UNINSTALL_APPLICATION.setEnabled(anySelected && !localAppSelected && !systemAppSelected);
         });
     }
 }

--- a/src/main/resources/assets/js/app/browse/ApplicationBrowsePanel.ts
+++ b/src/main/resources/assets/js/app/browse/ApplicationBrowsePanel.ts
@@ -23,8 +23,8 @@ import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
 import {SelectableListBoxPanel} from '@enonic/lib-admin-ui/ui/panel/SelectableListBoxPanel';
 import {SelectableListBoxWrapper, SelectionMode} from '@enonic/lib-admin-ui/ui/selector/list/SelectableListBoxWrapper';
 import {TreeGridContextMenu} from '@enonic/lib-admin-ui/ui/treegrid/TreeGridContextMenu';
-import {ListBoxToolbar} from '@enonic/lib-admin-ui/ui/selector/list/ListBoxToolbar';
 import {ApplicationsGridList} from './ApplicationsGridList';
+import {ApplicationsListToolbar} from './ApplicationsListToolbar';
 import {GetApplicationRequest} from '../resource/GetApplicationRequest';
 import Q from 'q';
 import {Element} from '@enonic/lib-admin-ui/dom/Element';
@@ -38,7 +38,7 @@ export class ApplicationBrowsePanel
 
     declare protected treeActions: ApplicationBrowseActions;
 
-    declare protected toolbar: ListBoxToolbar<Application>;
+    declare protected toolbar: ApplicationsListToolbar;
 
     declare protected contextMenu: TreeGridContextMenu;
 
@@ -122,8 +122,9 @@ export class ApplicationBrowsePanel
             highlightMode: true,
         });
 
-        this.toolbar = new ListBoxToolbar<Application>(this.selectionWrapper, {
+        this.toolbar = new ApplicationsListToolbar(this.selectionWrapper, {
             refreshAction: () => this.treeListBox.load(),
+            onHideSystemAppsToggled: (hide: boolean) => this.treeListBox.setHideSystemApps(hide),
         });
 
         if (!readonlyMode) {
@@ -165,7 +166,7 @@ export class ApplicationBrowsePanel
     }
 
     private handleAppEvent(event: ApplicationEvent) {
-        if (event.isSystemApplication() || event.getApplicationKey()?.toString() === 'com.enonic.xp.app.applications') {
+        if (event.getApplicationKey()?.toString() === 'com.enonic.xp.app.applications') {
             return;
         }
 

--- a/src/main/resources/assets/js/app/browse/ApplicationsGridList.ts
+++ b/src/main/resources/assets/js/app/browse/ApplicationsGridList.ts
@@ -30,4 +30,12 @@ export class ApplicationsGridList
             this.setItems(applications);
         }).catch(DefaultErrorHandler.handle);
     }
+
+    setHideSystemApps(hide: boolean): void {
+        this.toggleClass('hide-system-apps', hide);
+    }
+
+    isHidingSystemApps(): boolean {
+        return this.hasClass('hide-system-apps');
+    }
 }

--- a/src/main/resources/assets/js/app/browse/ApplicationsListToolbar.ts
+++ b/src/main/resources/assets/js/app/browse/ApplicationsListToolbar.ts
@@ -1,0 +1,35 @@
+import {Application} from '@enonic/lib-admin-ui/application/Application';
+import {ListBoxToolbar, ListBoxToolbarParams} from '@enonic/lib-admin-ui/ui/selector/list/ListBoxToolbar';
+import {SelectableListBoxWrapper} from '@enonic/lib-admin-ui/ui/selector/list/SelectableListBoxWrapper';
+import {TogglerButton} from '@enonic/lib-admin-ui/ui/button/TogglerButton';
+import {i18n} from '@enonic/lib-admin-ui/util/Messages';
+
+export interface ApplicationsListToolbarParams extends ListBoxToolbarParams {
+    onHideSystemAppsToggled: (hide: boolean) => void;
+}
+
+export class ApplicationsListToolbar extends ListBoxToolbar<Application> {
+
+    private readonly hideSystemAppsButton: TogglerButton;
+
+    constructor(listBoxWrapper: SelectableListBoxWrapper<Application>, params: ApplicationsListToolbarParams) {
+        super(listBoxWrapper, params);
+
+        const initialLabel = i18n('action.hideSystemApps');
+        this.hideSystemAppsButton = new TogglerButton('hide-system-apps-toggler icon-cog', initialLabel);
+        this.hideSystemAppsButton.setEnabled(true);
+        this.hideSystemAppsButton.setAriaLabel(initialLabel);
+        this.hideSystemAppsButton.onActiveChanged((isActive: boolean) => {
+            const label = i18n(isActive ? 'action.showSystemApps' : 'action.hideSystemApps');
+            this.hideSystemAppsButton.setTitle(label);
+            this.hideSystemAppsButton.setAriaLabel(label);
+            params.onHideSystemAppsToggled(isActive);
+        });
+
+        this.appendToRight(this.hideSystemAppsButton);
+    }
+
+    isHidingSystemApps(): boolean {
+        return this.hideSystemAppsButton.isActive();
+    }
+}

--- a/src/main/resources/assets/js/app/browse/ApplicationsListViewer.ts
+++ b/src/main/resources/assets/js/app/browse/ApplicationsListViewer.ts
@@ -4,6 +4,7 @@ import {ApplicationViewer} from '@enonic/lib-admin-ui/application/ApplicationVie
 import Q from 'q';
 import {SpanEl} from '@enonic/lib-admin-ui/dom/SpanEl';
 import {ProgressBar} from '@enonic/lib-admin-ui/ui/ProgressBar';
+import {SystemAppsHelper} from '../SystemAppsHelper';
 
 export class ApplicationsListViewer extends DivEl {
 
@@ -29,6 +30,10 @@ export class ApplicationsListViewer extends DivEl {
         this.itemViewer.setObject(application as Application);
         this.versionBlock.setItem(application);
         this.stateBlock.setItem(application);
+
+        const isSystem = application instanceof Application && SystemAppsHelper.get().isSystemApp(application);
+        this.toggleClass('system-app', isSystem);
+        this.itemViewer.toggleClass('system', isSystem);
     }
 
     getItem(): Application {

--- a/src/main/resources/assets/js/app/resource/GetApplicationRequest.ts
+++ b/src/main/resources/assets/js/app/resource/GetApplicationRequest.ts
@@ -4,9 +4,11 @@ import {ApplicationJson} from '@enonic/lib-admin-ui/application/json/Application
 import {JsonResponse} from '@enonic/lib-admin-ui/rest/JsonResponse';
 import {ApplicationCache} from '@enonic/lib-admin-ui/application/ApplicationCache';
 import {UrlHelper} from '../util/UrlHelper';
+import {SystemAppsHelper} from '../SystemAppsHelper';
 
-interface ApplicationJsonWithTitle extends ApplicationJson {
+interface ApplicationJsonExt extends ApplicationJson {
     title?: string;
+    system?: boolean;
 }
 
 export class GetApplicationRequest
@@ -16,9 +18,10 @@ export class GetApplicationRequest
         return UrlHelper.getRestUri('');
     }
 
-    protected parseResponse(response: JsonResponse<ApplicationJsonWithTitle>): Application {
+    protected parseResponse(response: JsonResponse<ApplicationJsonExt>): Application {
         const json = response.getResult();
         json.displayName = json.title || json.key;
+        SystemAppsHelper.get().setSystemFlag(json.key, !!json.system);
         const app = Application.fromJson(json);
         ApplicationCache.get().put(app);
         return app;

--- a/src/main/resources/assets/js/app/resource/ListApplicationsRequest.ts
+++ b/src/main/resources/assets/js/app/resource/ListApplicationsRequest.ts
@@ -3,13 +3,15 @@ import {Application} from '@enonic/lib-admin-ui/application/Application';
 import {ApplicationJson} from '@enonic/lib-admin-ui/application/json/ApplicationJson';
 import {JsonResponse} from '@enonic/lib-admin-ui/rest/JsonResponse';
 import {UrlHelper} from '../util/UrlHelper';
+import {SystemAppsHelper} from '../SystemAppsHelper';
 
-interface ApplicationJsonWithTitle extends ApplicationJson {
+interface ApplicationJsonExt extends ApplicationJson {
     title?: string;
+    system?: boolean;
 }
 
 interface ListApplicationsJson {
-    applications: ApplicationJsonWithTitle[];
+    applications: ApplicationJsonExt[];
 }
 
 export class ListApplicationsRequest
@@ -21,8 +23,10 @@ export class ListApplicationsRequest
 
     protected parseResponse(response: JsonResponse<ListApplicationsJson>): Application[] {
         const result = response.getResult();
-        result.applications?.forEach((app: ApplicationJsonWithTitle) => {
+        const helper = SystemAppsHelper.get();
+        result.applications?.forEach((app: ApplicationJsonExt) => {
             app.displayName = app.title || app.key;
+            helper.setSystemFlag(app.key, !!app.system);
         });
         return Application.fromJsonArray(result.applications);
     }

--- a/src/main/resources/assets/js/app/view/ApplicationItemStatisticsPanel.ts
+++ b/src/main/resources/assets/js/app/view/ApplicationItemStatisticsPanel.ts
@@ -12,6 +12,7 @@ import {Action} from '@enonic/lib-admin-ui/ui/Action';
 import {StartApplicationEvent} from '../browse/StartApplicationEvent';
 import {StopApplicationEvent} from '../browse/StopApplicationEvent';
 import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
+import {SystemAppsHelper} from '../SystemAppsHelper';
 import Q from 'q';
 
 export class ApplicationItemStatisticsPanel
@@ -71,9 +72,10 @@ export class ApplicationItemStatisticsPanel
     private updateActionMenu() {
         if (!!this.actionMenu) {
             const app: Application = this.getItem();
+            const isSystemApp: boolean = SystemAppsHelper.get().isSystemApp(app);
             this.actionMenu.setLabel(this.getLocalizedState(app.getState()));
-            this.startAction.setVisible(!app.isStarted());
-            this.stopAction.setVisible(app.isStarted());
+            this.startAction.setVisible(!app.isStarted() && !isSystemApp);
+            this.stopAction.setVisible(app.isStarted() && !isSystemApp);
         }
     }
 

--- a/src/main/resources/assets/styles/browse/application-tree-grid.less
+++ b/src/main/resources/assets/styles/browse/application-tree-grid.less
@@ -44,4 +44,31 @@
     }
   }
 
+  .application-viewer.system {
+    .names-and-icon-view .@{_COMMON_PREFIX}wrapper {
+      position: relative;
+
+      &::after {
+        font-family: 'icomoon', monospace;
+        content: "\e1df";
+        position: absolute;
+        right: -4px;
+        bottom: -4px;
+        font-size: 14px;
+        line-height: 14px;
+        color: @admin-bg-dark-gray;
+        background: @admin-white;
+        border-radius: 50%;
+        padding: 1px;
+        pointer-events: none;
+      }
+    }
+  }
+
+  &.hide-system-apps {
+    .item-view-wrapper:has(.applications-list-viewer.system-app) {
+      display: none;
+    }
+  }
+
 }

--- a/src/main/resources/i18n/phrases.properties
+++ b/src/main/resources/i18n/phrases.properties
@@ -10,6 +10,8 @@ admin.tool.description=Install and manage your Apps
 action.uninstall = Uninstall
 action.start = Start
 action.stop = Stop
+action.hideSystemApps = Hide system apps
+action.showSystemApps = Show system apps
 application.state.started = Started
 application.state.stopped = Stopped
 

--- a/src/main/resources/i18n/phrases_be.properties
+++ b/src/main/resources/i18n/phrases_be.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Схаваць сістэмныя дадаткі
+action.showSystemApps = Паказаць сістэмныя дадаткі
 action.start = Запусціць
 action.stop = Спыніць
 action.uninstall = Выдаліць

--- a/src/main/resources/i18n/phrases_de.properties
+++ b/src/main/resources/i18n/phrases_de.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Systemanwendungen ausblenden
+action.showSystemApps = Systemanwendungen anzeigen
 action.start = Starten
 action.stop = Stopp
 action.uninstall = Deinstallieren

--- a/src/main/resources/i18n/phrases_es.properties
+++ b/src/main/resources/i18n/phrases_es.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Ocultar aplicaciones del sistema
+action.showSystemApps = Mostrar aplicaciones del sistema
 action.start = Iniciar
 action.stop = Detener
 action.uninstall = Desinstalar

--- a/src/main/resources/i18n/phrases_fr.properties
+++ b/src/main/resources/i18n/phrases_fr.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Masquer les applications système
+action.showSystemApps = Afficher les applications système
 action.start = Démarrer
 action.stop = Arrêter
 action.uninstall = Désinstaller

--- a/src/main/resources/i18n/phrases_it.properties
+++ b/src/main/resources/i18n/phrases_it.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Nascondi applicazioni di sistema
+action.showSystemApps = Mostra applicazioni di sistema
 action.start = Inizia
 action.stop = Ferma
 action.uninstall = Disinstalla

--- a/src/main/resources/i18n/phrases_nl.properties
+++ b/src/main/resources/i18n/phrases_nl.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Systeemapps verbergen
+action.showSystemApps = Systeemapps tonen
 action.start = Start
 action.stop = Stop
 action.uninstall = Verwijderen

--- a/src/main/resources/i18n/phrases_no.properties
+++ b/src/main/resources/i18n/phrases_no.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Skjul systemapper
+action.showSystemApps = Vis systemapper
 action.start = Start
 action.stop = Stopp
 action.uninstall = Avinstaller

--- a/src/main/resources/i18n/phrases_pl.properties
+++ b/src/main/resources/i18n/phrases_pl.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Ukryj aplikacje systemowe
+action.showSystemApps = Pokaż aplikacje systemowe
 action.start = Start
 action.stop = Stop
 action.uninstall = Odinstaluj

--- a/src/main/resources/i18n/phrases_pt.properties
+++ b/src/main/resources/i18n/phrases_pt.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Ocultar aplicações do sistema
+action.showSystemApps = Mostrar aplicações do sistema
 action.start = Iniciar
 action.stop = Parar
 action.uninstall = Desinstalar

--- a/src/main/resources/i18n/phrases_ru.properties
+++ b/src/main/resources/i18n/phrases_ru.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Скрыть системные приложения
+action.showSystemApps = Показать системные приложения
 action.start = Запустить
 action.stop = Остановить
 action.uninstall = Удалить

--- a/src/main/resources/i18n/phrases_sv.properties
+++ b/src/main/resources/i18n/phrases_sv.properties
@@ -1,3 +1,5 @@
+action.hideSystemApps = Dölj systemappar
+action.showSystemApps = Visa systemappar
 action.start = Starta
 action.stop = Stoppa
 action.uninstall = Avinstallera

--- a/src/test/java/com/enonic/xp/app/applications/rest/resource/application/AppsApplicationResourceTest.java
+++ b/src/test/java/com/enonic/xp/app/applications/rest/resource/application/AppsApplicationResourceTest.java
@@ -234,7 +234,8 @@ public class AppsApplicationResourceTest
 
         final Applications applications = Applications.from( createApplication(), systemApp );
         when( this.applicationService.getInstalledApplications() ).thenReturn( applications );
-        when( this.applicationDescriptorService.get( ApplicationKey.from( "testapplication" ) ) ).thenReturn( createApplicationDescriptor() );
+        when( this.applicationDescriptorService.get( ApplicationKey.from( "testapplication" ) ) ).thenReturn(
+            createApplicationDescriptor() );
         when( cmsFormFragmentService.inlineFormItems( isA( Form.class ) ) ).then( AdditionalAnswers.returnsFirstArg() );
 
         String response = request().path( "application/list" ).get().getAsString();

--- a/src/test/java/com/enonic/xp/app/applications/rest/resource/application/AppsApplicationResourceTest.java
+++ b/src/test/java/com/enonic/xp/app/applications/rest/resource/application/AppsApplicationResourceTest.java
@@ -222,6 +222,28 @@ public class AppsApplicationResourceTest
     }
 
     @Test
+    public void getApplicationListIncludesSystemApps()
+        throws Exception
+    {
+        final Application systemApp = mock( Application.class );
+        when( systemApp.getKey() ).thenReturn( ApplicationKey.from( "com.enonic.xp.app.systemapp" ) );
+        when( systemApp.getVersion() ).thenReturn( Version.parseVersion( "1.0.0" ) );
+        when( systemApp.isSystem() ).thenReturn( true );
+        when( systemApp.isStarted() ).thenReturn( true );
+        when( systemApp.getModifiedTime() ).thenReturn( Instant.parse( "2012-01-01T00:00:00.00Z" ) );
+
+        final Applications applications = Applications.from( createApplication(), systemApp );
+        when( this.applicationService.getInstalledApplications() ).thenReturn( applications );
+        when( this.applicationDescriptorService.get( ApplicationKey.from( "testapplication" ) ) ).thenReturn( createApplicationDescriptor() );
+        when( cmsFormFragmentService.inlineFormItems( isA( Form.class ) ) ).then( AdditionalAnswers.returnsFirstArg() );
+
+        String response = request().path( "application/list" ).get().getAsString();
+        assertTrue( response.contains( "\"key\":\"com.enonic.xp.app.systemapp\"" ),
+                    "system app should be included in the list response" );
+        assertTrue( response.contains( "\"system\":true" ), "system flag should be exposed in JSON" );
+    }
+
+    @Test
     public void getApplicationListWithQuery()
         throws Exception
     {

--- a/src/test/resources/com/enonic/xp/app/applications/rest/resource/application/get_application_by_key_success.json
+++ b/src/test/resources/com/enonic/xp/app/applications/rest/resource/application/get_application_by_key_success.json
@@ -42,6 +42,7 @@
   "minSystemVersion": "5.0",
   "modifiedTime": "2012-01-01T00:00:00Z",
   "state": "started",
+  "system": false,
   "title": "application display name",
   "url": "http://enonic.net",
   "vendorName": "Enonic",

--- a/src/test/resources/com/enonic/xp/app/applications/rest/resource/application/get_application_i18n.json
+++ b/src/test/resources/com/enonic/xp/app/applications/rest/resource/application/get_application_i18n.json
@@ -44,6 +44,7 @@
   "minSystemVersion": "5.0",
   "modifiedTime": "2012-01-01T00:00:00Z",
   "state": "started",
+  "system": false,
   "title": "application display name",
   "url": "http://enonic.net",
   "vendorName": "Enonic",

--- a/src/test/resources/com/enonic/xp/app/applications/rest/resource/application/get_application_list_success.json
+++ b/src/test/resources/com/enonic/xp/app/applications/rest/resource/application/get_application_list_success.json
@@ -44,6 +44,7 @@
       "minSystemVersion": "5.0",
       "modifiedTime": "2012-01-01T00:00:00Z",
       "state": "started",
+      "system": false,
       "title": "application display name",
       "url": "http://enonic.net",
       "vendorName": "Enonic",

--- a/testing/libs/app_const.js
+++ b/testing/libs/app_const.js
@@ -16,6 +16,7 @@ module.exports = Object.freeze({
         TEST_APP_WITH_METADATA_MIXIN: 'Test Selenium App',
         MY_FIRST_APP: 'My First App',
         TEST_ADFS_PROVIDER_APP: 'Test ADFS ID Provider',
+        STANDARD_ID_PROVIDER_APP: 'Standard ID Provider',
     },
 
     TEST_IMAGES: {

--- a/testing/page_objects/applications/applications.browse.panel.js
+++ b/testing/page_objects/applications/applications.browse.panel.js
@@ -9,7 +9,10 @@ const XPATH = {
     GRID_LIST_ITEM: "//li[contains(@class,'item-view-wrapper')]",
     toolbar: "//div[contains(@id,'Toolbar')]",
     contextMenu: "//ul[contains(@class,'context-menu')]",
-    treeGridToolbarDiv: `//div[contains(@id,'ListBoxToolbar')]`,
+    treeGridToolbarDiv: `//div[contains(@class,'tree-grid-toolbar')]`,
+    hideSystemAppsToggle: "//button[contains(@class,'hide-system-apps-toggler')]",
+    systemAppRow: "//li[contains(@class,'item-view-wrapper') and descendant::div[contains(@class,'applications-list-viewer') and contains(@class,'system-app')]]",
+    systemAppViewerByName: displayName => `//li[contains(@class,'item-view-wrapper') and descendant::h6[contains(@class,'main-name') and contains(.,'${displayName}')]]//div[contains(@class,'application-viewer') and contains(@class,'system')]`,
     installButton: `//div[contains(@id,'Toolbar')]/button[contains(@id, 'ActionButton') and child::span[contains(.,'Install')]]`,
     unInstallButton: `//div[contains(@id,'Toolbar')]/button[contains(@id, 'ActionButton') and child::span[contains(.,'Uninstall')]]`,
     stopButton: "//div[contains(@id,'Toolbar')]/button[contains(@id, 'ActionButton') and child::span[contains(.,'Stop')]]",
@@ -456,6 +459,52 @@ class AppBrowsePanel extends Page {
         await this.waitForElementDisplayed(locator);
         let attribute = await this.getAttribute(locator, 'class');
         return attribute.includes('selected') && !attribute.includes('checked');
+    }
+
+    async getSystemAppDisplayNames() {
+        try {
+            const displayNameXpath = XPATH.systemAppRow + lib.H6_DISPLAY_NAME;
+            return await this.getTextInDisplayedElements(displayNameXpath);
+        } catch (err) {
+            await this.handleError('Getting system application display names', 'err_get_system_app_display_names', err);
+        }
+    }
+
+    async isSystemAppRowDisplayed(appDisplayName) {
+        try {
+            const locator = `//li[contains(@class,'item-view-wrapper') and descendant::div[contains(@class,'applications-list-viewer') and contains(@class,'system-app')] and descendant::h6[contains(@class,'main-name') and contains(.,'${appDisplayName}')]]`;
+            return await this.isElementDisplayed(locator);
+        } catch (err) {
+            return false;
+        }
+    }
+
+    async hasCogOverlayForSystemApp(appDisplayName) {
+        try {
+            const locator = XPATH.systemAppViewerByName(appDisplayName);
+            return await this.isElementDisplayed(locator);
+        } catch (err) {
+            return false;
+        }
+    }
+
+    async clickOnHideSystemAppsToggle() {
+        try {
+            await this.waitForElementDisplayed(XPATH.hideSystemAppsToggle);
+            await this.clickOnElement(XPATH.hideSystemAppsToggle);
+            return await this.pause(500);
+        } catch (err) {
+            await this.handleError('Click on hide-system-apps toggle', 'err_click_hide_system_apps', err);
+        }
+    }
+
+    async isHideSystemAppsToggleActive() {
+        try {
+            const attr = await this.getAttribute(XPATH.hideSystemAppsToggle, 'class');
+            return attr.includes('active');
+        } catch (err) {
+            return false;
+        }
     }
 }
 

--- a/testing/specs/app.browse.panel.multiple.selections.spec.js
+++ b/testing/specs/app.browse.panel.multiple.selections.spec.js
@@ -85,19 +85,19 @@ describe('Application Browse Panel, multiple selection in grid', function () {
             await appBrowsePanel.waitForContextMenuItemEnabled('Stop');
         });
 
-    it('GIVEN at least one app is stopped AND `select all` checkbox is checked WHEN right click on selected apps THEN Start and Stop menu item should be enabled in the opened context menu',
+    it('GIVEN at least one app is stopped AND `select all` checkbox is checked WHEN right click on selected apps THEN Start should be enabled but Stop should be disabled (system apps in selection)',
         async () => {
             let appBrowsePanel = new AppBrowsePanel();
-            // 1. Select all applications(one app is stopped):
+            // 1. Select all applications(one app is stopped); system apps are included:
             await appBrowsePanel.clickOnSelectAllCheckbox();
             // 2. Open the context menu:
             await appBrowsePanel.rightClickOnRowByDisplayName(appConst.TEST_APPS_NAME.MY_FIRST_APP);
             await appBrowsePanel.waitForContextMenuDisplayed();
             await studioUtils.saveScreenshot('all_apps_context_menu');
-            // 3. Verify that Start and Stop menu items are enabled:
+            // 3. Start should be enabled (some apps are stopped):
             await appBrowsePanel.waitForContextMenuItemEnabled('Start');
-            // 'Stop' menu item should be enabled'
-            await appBrowsePanel.waitForContextMenuItemEnabled('Stop');
+            // Stop should be disabled because system apps are part of the selection:
+            await appBrowsePanel.waitForContextMenuItemDisabled('Stop');
         });
 
     beforeEach(() => studioUtils.navigateToApplicationsApp());

--- a/testing/specs/app.browse.panel.selection.spec.js
+++ b/testing/specs/app.browse.panel.selection.spec.js
@@ -63,11 +63,11 @@ describe('Applications Browse panel - selection of items spec', function () {
             await studioUtils.saveScreenshot('arrow_down_key');
             // 3. Verify that another application is shown in the Statistic Panel
             let appName = await appStatisticPanel.getApplicationName();
-            assert.equal(appName, appConst.TEST_APPS_NAME.TEST_ADFS_PROVIDER_APP,
+            assert.equal(appName, appConst.TEST_APPS_NAME.STANDARD_ID_PROVIDER_APP,
                 'the application which is below should be shown in the Statistic Panel');
             isChecked = await appBrowsePanel.isRowChecked(appConst.TEST_APPS_NAME.SIMPLE_SITE_APP);
             assert.ok(isChecked === false, 'the application should not be checked');
-            let isHighlighted = await appBrowsePanel.isRowHighlighted(appConst.TEST_APPS_NAME.TEST_ADFS_PROVIDER_APP);
+            let isHighlighted = await appBrowsePanel.isRowHighlighted(appConst.TEST_APPS_NAME.STANDARD_ID_PROVIDER_APP);
             assert.ok(isHighlighted, 'but the app which is below gets highlighted');
         });
 
@@ -82,13 +82,13 @@ describe('Applications Browse panel - selection of items spec', function () {
             await studioUtils.saveScreenshot('arrow_up_key');
             // 3. Verify the application which is above should be shown in the Statistic Panel
             let result = await appStatisticPanel.getApplicationName();
-            assert.equal(result, appConst.TEST_APPS_NAME.SIMPLE_SITE_APP,
+            assert.equal(result, appConst.TEST_APPS_NAME.STANDARD_ID_PROVIDER_APP,
                 'the application which is above should be shown in the Statistic Panel');
             // 4. Verify that the gets unchecked:
             let isChecked = await appBrowsePanel.isRowChecked(appConst.TEST_APPS_NAME.TEST_ADFS_PROVIDER_APP);
             assert.ok(isChecked === false, 'the application should not be checked');
             // 5. Verify that the application which is above gets highlighted:
-            let isHighlighted = await appBrowsePanel.isRowHighlighted(appConst.TEST_APPS_NAME.SIMPLE_SITE_APP);
+            let isHighlighted = await appBrowsePanel.isRowHighlighted(appConst.TEST_APPS_NAME.STANDARD_ID_PROVIDER_APP);
             assert.ok(isHighlighted, 'but the app which is above above gets highlighted');
         });
 

--- a/testing/specs/app.browse.panel.system.apps.spec.js
+++ b/testing/specs/app.browse.panel.system.apps.spec.js
@@ -1,0 +1,76 @@
+const assert = require('node:assert');
+const webDriverHelper = require('../libs/WebDriverHelper');
+const AppBrowsePanel = require('../page_objects/applications/applications.browse.panel');
+const studioUtils = require('../libs/studio.utils.js');
+const appConst = require('../libs/app_const');
+
+describe('Applications Browse panel - system apps spec', function () {
+    this.timeout(appConst.SUITE_TIMEOUT);
+
+    if (typeof browser === 'undefined') {
+        webDriverHelper.setupBrowser();
+    }
+
+    it(`GIVEN apps grid is loaded THEN at least one system app should be shown by default`,
+        async () => {
+            let appBrowsePanel = new AppBrowsePanel();
+            await appBrowsePanel.waitForGridLoaded();
+            const systemApps = await appBrowsePanel.getSystemAppDisplayNames();
+            await studioUtils.saveScreenshot('system_apps_visible_by_default');
+            assert.ok(systemApps && systemApps.length > 0,
+                'at least one system application should be displayed by default');
+        });
+
+    it(`GIVEN apps grid is loaded THEN every system app row should carry the cog overlay`,
+        async () => {
+            let appBrowsePanel = new AppBrowsePanel();
+            await appBrowsePanel.waitForGridLoaded();
+            const systemApps = await appBrowsePanel.getSystemAppDisplayNames();
+            assert.ok(systemApps.length > 0, 'expected at least one system app to verify');
+            for (const name of systemApps) {
+                const hasCog = await appBrowsePanel.hasCogOverlayForSystemApp(name);
+                assert.ok(hasCog, `system app '${name}' should have the cog overlay class`);
+            }
+        });
+
+    it(`GIVEN system apps are visible WHEN the 'Hide system apps' toggle is clicked THEN system apps should disappear`,
+        async () => {
+            let appBrowsePanel = new AppBrowsePanel();
+            await appBrowsePanel.waitForGridLoaded();
+            const before = await appBrowsePanel.getSystemAppDisplayNames();
+            assert.ok(before.length > 0, 'system apps should be visible before toggling');
+            await appBrowsePanel.clickOnHideSystemAppsToggle();
+            await studioUtils.saveScreenshot('system_apps_hidden');
+            assert.ok(await appBrowsePanel.isHideSystemAppsToggleActive(),
+                'hide-system-apps toggle should be active');
+            for (const name of before) {
+                const stillShown = await appBrowsePanel.isSystemAppRowDisplayed(name);
+                assert.ok(!stillShown, `system app '${name}' should be hidden after toggling`);
+            }
+            // restore default state
+            await appBrowsePanel.clickOnHideSystemAppsToggle();
+        });
+
+    it(`GIVEN a system app is selected THEN Stop and Uninstall actions should be disabled`,
+        async () => {
+            let appBrowsePanel = new AppBrowsePanel();
+            await appBrowsePanel.waitForGridLoaded();
+            const systemApps = await appBrowsePanel.getSystemAppDisplayNames();
+            assert.ok(systemApps.length > 0, 'expected at least one system app to select');
+            const target = systemApps[0];
+            await appBrowsePanel.clickOnCheckboxAndSelectRowByDisplayName(target);
+            await studioUtils.saveScreenshot('system_app_selected');
+            const stopEnabled = await appBrowsePanel.isStopButtonEnabled();
+            const uninstallEnabled = await appBrowsePanel.isUninstallButtonEnabled();
+            assert.equal(stopEnabled, false, `Stop should be disabled for system app '${target}'`);
+            assert.equal(uninstallEnabled, false, `Uninstall should be disabled for system app '${target}'`);
+            // deselect
+            await appBrowsePanel.clickOnCheckboxAndSelectRowByDisplayName(target);
+        });
+
+    beforeEach(() => studioUtils.navigateToApplicationsApp());
+    afterEach(() => studioUtils.goToHomePage());
+    before(() => {
+        return console.log('specification is starting: ' + this.title);
+    });
+});


### PR DESCRIPTION
Closes #141.

System apps are no longer hidden from the apps list. Per the issue
discussion (sigdestad / alansemenov):

- System apps are listed alongside normal apps, marked with a cog
  icon overlay (mirroring the system-principal treatment in user
  manager).
- A new toolbar toggle hides/shows system apps on demand;
  default is to show them.
- Stop and Uninstall actions are disabled for any selection that
  includes a system app.

## Backend
- `AppsApplicationResource#list` no longer skips system apps.
- `ApplicationJson` exposes a new `system` boolean field.
- `AppsApplicationResourceTest` adds a case asserting a system app
  is returned in the list response with `"system":true`.

## Frontend
- `SystemAppsHelper` keeps a `Set` of keys flagged as system; populated
  by `ListApplicationsRequest` / `GetApplicationRequest` while parsing.
- `ApplicationsListViewer` toggles a `system-app` / `system` class on
  the row, and the LESS rule overlays a cog icon (`\e1df` / icomoon).
- `ApplicationsListToolbar` (new) extends `ListBoxToolbar` with a
  `TogglerButton` for "Hide / Show system apps".
- `ApplicationBrowseActions` disables Stop and Uninstall whenever any
  selected row is a system app.

## i18n
New `action.hideSystemApps` / `action.showSystemApps` strings added in
all twelve `phrases_*.properties` files.

## Verification
- `./gradlew build` succeeds (Java tests + tsc + eslint).
- New WDIO spec `testing/specs/app.browse.panel.system.apps.spec.js`
  covers: visibility, cog overlay, filter toggle (hide / restore),
  and disabled Stop / Uninstall on a system app row.